### PR TITLE
Update NettyHeaderDelimiterFrameDecoder.java

### DIFF
--- a/src/main/java/com/wjy/sl6512014/server/codec/NettyHeaderDelimiterFrameDecoder.java
+++ b/src/main/java/com/wjy/sl6512014/server/codec/NettyHeaderDelimiterFrameDecoder.java
@@ -55,9 +55,9 @@ public class NettyHeaderDelimiterFrameDecoder extends ByteToMessageDecoder {
         // 累积数据，直到包含两个头标识符，截取数据返回一个包
         if (startIndex > 0) {
             // 丢弃标识符左区间前的数据
-            buffer.skipBytes(startIndex);
+            buffer.skipBytes(startIndex/2);
         }
         // TODO 若后续没有数据，最后一个包将永远得不到处理
-        return buffer.readRetainedSlice(endIndex - startIndex);
+        return buffer.readRetainedSlice((endIndex - startIndex)/2);
     }
 }


### PR DESCRIPTION
ByteBufUtil.hexDump(buffer)方法将buffer中的字节数据转换为十六进制字符串。这意味着每个字节会被转换为两个十六进制字符。因此，十六进制字符串的长度是字节数据长度的两倍。因此需要除以2，得到正确的字节长度。